### PR TITLE
gitignore en la carpeta Proteus

### DIFF
--- a/Proteus/.gitignore
+++ b/Proteus/.gitignore
@@ -1,0 +1,3 @@
+**/Proyect Backups
+
+.workspace


### PR DESCRIPTION
Creación de gitignore para evitar archivos temporales de Proteus